### PR TITLE
refactor: fetch Brent crude data from dataset repo

### DIFF
--- a/app/composables/useFuelPrices.ts
+++ b/app/composables/useFuelPrices.ts
@@ -1,6 +1,9 @@
 import { prices as fallbackPrices, DATA_SOURCE, type FuelPriceEntry } from '~/data/prices'
+import { brentPrices as fallbackBrent, type BrentPriceEntry } from '~/data/brent'
 
-const DATASET_URL = 'https://raw.githubusercontent.com/MrSunshyne/mauritius-dataset-fuel/main/data/prices.json'
+const DATASET_BASE = 'https://raw.githubusercontent.com/MrSunshyne/mauritius-dataset-fuel/main/data'
+const PRICES_URL = `${DATASET_BASE}/prices.json`
+const BRENT_URL = `${DATASET_BASE}/brent.json`
 
 export type SortField = 'date' | 'petrol' | 'diesel' | 'spread'
 export type SortDirection = 'asc' | 'desc'
@@ -8,24 +11,31 @@ export type SortDirection = 'asc' | 'desc'
 const sortField = ref<SortField>('date')
 const sortDirection = ref<SortDirection>('desc')
 const livePrices = ref<FuelPriceEntry[] | null>(null)
+const liveBrent = ref<BrentPriceEntry[] | null>(null)
 
 export function useFuelPrices() {
   // Use live data if fetched, otherwise fall back to bundled data
   const prices = computed(() => livePrices.value ?? fallbackPrices)
+  const brentPrices = computed(() => liveBrent.value ?? fallbackBrent)
 
   // Fetch live data from the dataset repo
   async function fetchLiveData() {
-    try {
-      const res = await fetch(DATASET_URL)
-      if (!res.ok) return
-      const data: FuelPriceEntry[] = await res.json()
-      if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].petrol != null) {
-        livePrices.value = data
-      }
-    }
-    catch {
-      // Silently fall back to bundled data
-    }
+    const results = await Promise.allSettled([
+      fetch(PRICES_URL).then(async (res) => {
+        if (!res.ok) return
+        const data: FuelPriceEntry[] = await res.json()
+        if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].petrol != null) {
+          livePrices.value = data
+        }
+      }),
+      fetch(BRENT_URL).then(async (res) => {
+        if (!res.ok) return
+        const data: BrentPriceEntry[] = await res.json()
+        if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].price != null) {
+          liveBrent.value = data
+        }
+      }),
+    ])
   }
 
   const currentPrices = computed(() => prices.value[0])
@@ -146,6 +156,7 @@ export function useFuelPrices() {
 
   return {
     prices,
+    brentPrices,
     currentPrices,
     lastChange,
     allTimePetrolHigh,

--- a/app/pages/comparison.vue
+++ b/app/pages/comparison.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { brentPrices } from '~/data/brent'
-
-const { chronologicalPrices, formatDate, formatPrice } = useFuelPrices()
+const { brentPrices, chronologicalPrices, formatDate, formatPrice } = useFuelPrices()
 
 useSeoMeta({
   title: 'Global Comparison - Mauritius Fuel Prices',
@@ -18,7 +16,7 @@ interface TimelinePoint {
 const timeline = computed<TimelinePoint[]>(() => {
   const muPrices = chronologicalPrices.value
   const points: TimelinePoint[] = []
-  for (const b of brentPrices) {
+  for (const b of brentPrices.value) {
     // Use last day of the month so price changes late in the month are captured
     const [y, m] = b.date.split('-').map(Number)
     const bDate = new Date(y, m, 0) // day 0 of next month = last day of this month

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { brentPrices } from '~/data/brent'
-
 const {
   currentPrices,
   lastChange,
@@ -8,6 +6,7 @@ const {
   dieselPeak,
   petrolFloor,
   dieselFloor,
+  brentPrices,
   chronologicalPrices,
   formatDate,
   formatPrice,
@@ -31,7 +30,7 @@ interface TimelinePoint {
 const timeline = computed<TimelinePoint[]>(() => {
   const muPrices = chronologicalPrices.value
   const points: TimelinePoint[] = []
-  for (const b of brentPrices) {
+  for (const b of brentPrices.value) {
     // Use last day of the month so price changes late in the month are captured
     const [y, m] = b.date.split('-').map(Number)
     const bDate = new Date(y, m, 0) // day 0 of next month = last day of this month


### PR DESCRIPTION
## Summary

- Brent crude prices are now fetched live from `mauritius-dataset-fuel/data/brent.json` instead of being hardcoded in `app/data/brent.ts`
- Both price and brent fetches run in parallel on mount via `Promise.allSettled`
- `brent.ts` is kept as a bundled fallback (same pattern as `prices.ts`)

## Why

The chart was broken for the March 2026 diesel price hike because `brent.ts` didn't have a `2026-03` entry. The chart timeline is built by iterating over brent months, so without that entry the chart stopped at February. This will keep happening every month without manual PRs.

With this change, the dataset repo's CI keeps brent data up to date automatically (see [mauritius-dataset-fuel#3](https://github.com/MrSunshyne/mauritius-dataset-fuel/pull/3)), and the app picks it up on each page load.

## Depends on

- https://github.com/MrSunshyne/mauritius-dataset-fuel/pull/3 (adds `brent.json` and `fetch-brent.mjs` to the dataset repo)

## Files changed

- `app/composables/useFuelPrices.ts` — added brent fetch, exports reactive `brentPrices`
- `app/pages/index.vue` — removed `import { brentPrices } from '~/data/brent'`, uses composable
- `app/pages/comparison.vue` — same change