### PR TITLE
feat: animate prices and chart on data load

### DIFF
--- a/app/composables/useAnimatedNumber.ts
+++ b/app/composables/useAnimatedNumber.ts
@@ -1,0 +1,37 @@
+export function useAnimatedNumber(
+  target: Ref<number> | ComputedRef<number>,
+  options: { duration?: number; delay?: number } = {},
+) {
+  const { duration = 900, delay = 0 } = options
+  const display = ref(0)
+  let raf: number | undefined
+
+  function animate(from: number, to: number) {
+    if (raf) cancelAnimationFrame(raf)
+    const start = performance.now() + delay
+    function tick(now: number) {
+      const elapsed = now - start
+      if (elapsed < 0) {
+        raf = requestAnimationFrame(tick)
+        return
+      }
+      const progress = Math.min(elapsed / duration, 1)
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3)
+      display.value = from + (to - from) * eased
+      if (progress < 1) {
+        raf = requestAnimationFrame(tick)
+      }
+    }
+    raf = requestAnimationFrame(tick)
+  }
+
+  watch(
+    () => unref(target),
+    (newVal, oldVal) => {
+      animate(oldVal ?? 0, newVal)
+    },
+  )
+
+  return display
+}

--- a/app/composables/useFuelPrices.ts
+++ b/app/composables/useFuelPrices.ts
@@ -12,6 +12,7 @@ const sortField = ref<SortField>('date')
 const sortDirection = ref<SortDirection>('desc')
 const livePrices = ref<FuelPriceEntry[] | null>(null)
 const liveBrent = ref<BrentPriceEntry[] | null>(null)
+const dataReady = ref(false)
 
 export function useFuelPrices() {
   // Use live data if fetched, otherwise fall back to bundled data
@@ -20,22 +21,27 @@ export function useFuelPrices() {
 
   // Fetch live data from the dataset repo
   async function fetchLiveData() {
-    const results = await Promise.allSettled([
-      fetch(PRICES_URL).then(async (res) => {
-        if (!res.ok) return
-        const data: FuelPriceEntry[] = await res.json()
-        if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].petrol != null) {
-          livePrices.value = data
-        }
-      }),
-      fetch(BRENT_URL).then(async (res) => {
-        if (!res.ok) return
-        const data: BrentPriceEntry[] = await res.json()
-        if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].price != null) {
-          liveBrent.value = data
-        }
-      }),
-    ])
+    try {
+      await Promise.allSettled([
+        fetch(PRICES_URL).then(async (res) => {
+          if (!res.ok) return
+          const data: FuelPriceEntry[] = await res.json()
+          if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].petrol != null) {
+            livePrices.value = data
+          }
+        }),
+        fetch(BRENT_URL).then(async (res) => {
+          if (!res.ok) return
+          const data: BrentPriceEntry[] = await res.json()
+          if (Array.isArray(data) && data.length > 0 && data[0].date && data[0].price != null) {
+            liveBrent.value = data
+          }
+        }),
+      ])
+    }
+    finally {
+      dataReady.value = true
+    }
   }
 
   const currentPrices = computed(() => prices.value[0])
@@ -157,6 +163,7 @@ export function useFuelPrices() {
   return {
     prices,
     brentPrices,
+    dataReady,
     currentPrices,
     lastChange,
     allTimePetrolHigh,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const {
+  dataReady,
   currentPrices,
   lastChange,
   petrolPeak,
@@ -13,6 +14,12 @@ const {
   DATA_SOURCE,
   timeAgo,
 } = useFuelPrices()
+
+// Animated price display — starts at 0, counts up when data arrives
+const petrolTarget = computed(() => dataReady.value ? currentPrices.value.petrol : 0)
+const dieselTarget = computed(() => dataReady.value ? currentPrices.value.diesel : 0)
+const animatedPetrol = useAnimatedNumber(petrolTarget, { duration: 1000 })
+const animatedDiesel = useAnimatedNumber(dieselTarget, { duration: 1000, delay: 100 })
 
 useSeoMeta({
   title: 'Mauritius Fuel Prices - Petrol & Diesel Price Tracker',
@@ -247,13 +254,13 @@ function formatMonth(dateStr: string): string {
           </div>
         </div>
         <div class="card-body">
-          <div class="price-value">{{ formatPrice(currentPrices.petrol) }}</div>
-          <div class="price-change" :class="{ up: lastChange.petrol > 0, down: lastChange.petrol < 0 }">
+          <div class="price-value">Rs {{ animatedPetrol.toFixed(2) }}</div>
+          <div v-if="dataReady" class="price-change" :class="{ up: lastChange.petrol > 0, down: lastChange.petrol < 0 }">
             <span class="change-icon">{{ lastChange.petrol > 0 ? '▲' : '▼' }}</span>
             <span class="change-val">{{ Math.abs(lastChange.petrol).toFixed(2) }} MUR</span>
           </div>
         </div>
-        <div class="card-footer">
+        <div v-if="dataReady" class="card-footer">
           Since {{ formatDate(lastChange.sinceDate) }}
         </div>
       </div>
@@ -273,19 +280,19 @@ function formatMonth(dateStr: string): string {
           </div>
         </div>
         <div class="card-body">
-          <div class="price-value">{{ formatPrice(currentPrices.diesel) }}</div>
-          <div class="price-change" :class="{ up: lastChange.diesel > 0, down: lastChange.diesel < 0 }">
+          <div class="price-value">Rs {{ animatedDiesel.toFixed(2) }}</div>
+          <div v-if="dataReady" class="price-change" :class="{ up: lastChange.diesel > 0, down: lastChange.diesel < 0 }">
             <span class="change-icon">{{ lastChange.diesel > 0 ? '▲' : '▼' }}</span>
             <span class="change-val">{{ Math.abs(lastChange.diesel).toFixed(2) }} MUR</span>
           </div>
         </div>
-        <div class="card-footer">
+        <div v-if="dataReady" class="card-footer">
           Since {{ formatDate(lastChange.sinceDate) }}
         </div>
       </div>
 
       <!-- CHART SECTION -->
-      <section class="bento-item chart-section">
+      <section class="bento-item chart-section" :class="{ 'chart-ready': dataReady }">
         <div class="section-header">
           <h3>Historical Analysis</h3>
           <div class="chart-legend">
@@ -437,7 +444,7 @@ function formatMonth(dateStr: string): string {
       </section>
 
       <!-- EXTREMES -->
-      <section class="bento-item extremes">
+      <section v-if="dataReady" class="bento-item extremes">
         <div class="section-header">
           <h3>Market Extremes</h3>
         </div>
@@ -764,11 +771,16 @@ function formatMonth(dateStr: string): string {
   letter-spacing: 0.05em;
 }
 
-.area-brent { fill: var(--brent-color); opacity: 0.03; }
-.line-brent { stroke: var(--brent-color); stroke-width: 1.5; opacity: 0.3; }
+.area-brent { fill: var(--brent-color); opacity: 0; transition: opacity 0.8s ease 0.6s; }
+.chart-ready .area-brent { opacity: 0.03; }
 
-.line-petrol { stroke: var(--petrol-color); stroke-width: 2.5; transition: all 0.2s; }
-.line-diesel { stroke: var(--diesel-color); stroke-width: 2.5; transition: all 0.2s; }
+.line-brent { stroke: var(--brent-color); stroke-width: 1.5; opacity: 0.3; stroke-dasharray: 3000; stroke-dashoffset: 3000; }
+.chart-ready .line-brent { stroke-dashoffset: 0; transition: stroke-dashoffset 2s ease-out 0.3s; }
+
+.line-petrol { stroke: var(--petrol-color); stroke-width: 2.5; transition: all 0.2s; stroke-dasharray: 3000; stroke-dashoffset: 3000; }
+.line-diesel { stroke: var(--diesel-color); stroke-width: 2.5; transition: all 0.2s; stroke-dasharray: 3000; stroke-dashoffset: 3000; }
+.chart-ready .line-petrol { stroke-dashoffset: 0; transition: stroke-dashoffset 1.8s ease-out 0.5s, opacity 0.2s, stroke-width 0.2s; }
+.chart-ready .line-diesel { stroke-dashoffset: 0; transition: stroke-dashoffset 1.8s ease-out 0.7s, opacity 0.2s, stroke-width 0.2s; }
 
 .line-petrol.dimmed, .line-diesel.dimmed { opacity: 0.1; stroke-width: 1; }
 .line-petrol.highlighted, .line-diesel.highlighted { stroke-width: 4; }


### PR DESCRIPTION
## Problem

When the page loads, the fallback bundled prices flash briefly before being replaced by live data. This creates a jarring number jump that looks broken.

## Solution

### Animated price count-up
- Prices start at `Rs 0.00` and count up to the real value over 1 second (cubic ease-out)
- Diesel starts 100ms after petrol for a staggered feel
- Change indicators ("+ 5.85 MUR") and footers are hidden until data is ready (`v-if="dataReady"`)
- New `useAnimatedNumber` composable — `requestAnimationFrame`-based, supports configurable duration and delay

### Chart draw-in animation
- SVG lines draw in using `stroke-dashoffset` transition, staggered: brent (0.3s delay), petrol (0.5s), diesel (0.7s)
- Brent area fill fades in after 0.6s
- Triggered by a `chart-ready` CSS class that activates when `dataReady` becomes true

### Extremes section
- Hidden entirely until data loads (`v-if="dataReady"`) to avoid showing fallback peaks/floors

## Files changed
- `app/composables/useAnimatedNumber.ts` — new composable
- `app/composables/useFuelPrices.ts` — added `dataReady` ref
- `app/pages/index.vue` — animated values in template, CSS draw-in animations