### PR TITLE
Fix missing data after navigating to other routes

### DIFF
--- a/app/composables/useAnimatedNumber.ts
+++ b/app/composables/useAnimatedNumber.ts
@@ -7,6 +7,11 @@ export function useAnimatedNumber(
   let raf: number | undefined
 
   function animate(from: number, to: number) {
+    if (typeof requestAnimationFrame !== 'function') {
+      display.value = to
+      return
+    }
+
     if (raf) cancelAnimationFrame(raf)
     const start = performance.now() + delay
     function tick(now: number) {

--- a/app/composables/useAnimatedNumber.ts
+++ b/app/composables/useAnimatedNumber.ts
@@ -31,6 +31,7 @@ export function useAnimatedNumber(
     (newVal, oldVal) => {
       animate(oldVal ?? 0, newVal)
     },
+    { immediate: true },
   )
 
   return display


### PR DESCRIPTION
**Bug**: Petrol & Diesel prices are set to **Rs 00.00** after navigating to other routes, then back to the homepage

**Steps to reproduce**:
1. Navigate to homepage
2. Navigate to `/history`
3. Navigate to homepage
4. Notice **Petrol & Diesel prices** are **Rs 00.00**

**Fix**:
- Add immediate option to the watcher in `app/composables/useAnimatedNumber.ts` - triggering the callback immediately after it is created
- Add SSR guard as the immediate option triggers the watcher during server render