### PR TITLE
fix: show correct since date on price cards

### DIFF
--- a/app/composables/useFuelPrices.ts
+++ b/app/composables/useFuelPrices.ts
@@ -55,7 +55,7 @@ export function useFuelPrices() {
         return {
           petrol: +(curr.petrol - p[i].petrol).toFixed(2),
           diesel: +(curr.diesel - p[i].diesel).toFixed(2),
-          sinceDate: p[i].date,
+          sinceDate: p[i - 1].date,
         }
       }
     }


### PR DESCRIPTION
## Problem

The "Since" date on fuel price cards was showing the wrong date — it displayed when the *previous* price was set, not when the *current* price came into effect.

**Example with today's data:**
- `p[0]` = 2026-04-16: petrol 64.25, diesel 71.25 ← current prices
- `p[1]` = 2026-03-25: petrol 58.45, diesel 64.8 ← previous prices

The loop found the first differing entry at `i = 1` and returned `p[i].date = "2026-03-25"`, so cards showed **"Since 25 Mar 2026"** even though prices changed on **16 Apr 2026**.

## Fix

Changed `sinceDate: p[i].date` → `sinceDate: p[i - 1].date` in `useFuelPrices.ts`.

When the differing entry is found at index `i`, `p[i - 1]` is the last entry that still held the current price — which is the correct "since" date.

## File changed

`app/composables/useFuelPrices.ts` line 58 — one character change.