### PR TITLE
fix: derive Last Updated date from price data instead of hardcoded string

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -215,6 +215,17 @@ function formatMonth(dateStr: string): string {
   const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
   return `${months[parseInt(month) - 1]} ${year}`
 }
+
+// Date of the most recent price entry; formatted in UTC so the
+// YYYY-MM-DD string doesn't shift a day in western timezones
+const lastUpdated = computed(() => {
+  return new Date(currentPrices.value.date).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+})
 </script>
 
 <template>
@@ -230,7 +241,7 @@ function formatMonth(dateStr: string): string {
         <div class="hero-meta">
           <div class="meta-item">
             <span class="meta-label">Last Updated</span>
-            <span class="meta-value">March 15, 2026</span>
+            <span class="meta-value">{{ lastUpdated }}</span>
           </div>
           <div class="meta-item">
             <span class="meta-label">Status</span>


### PR DESCRIPTION
## Problem

The hero section on production shows **Last Updated: March 15, 2026**, but the fuel prices themselves are from **April 16, 2026** (matching the STC source). The date was a hardcoded string in `app/pages/index.vue`, so it went stale every time the dataset updated.

## Fix

Replace the hardcoded string with a computed value derived from the most recent price entry (`currentPrices.date`), which comes from the live dataset fetch (with the bundled data as fallback). It's formatted in the same "Month D, YYYY" style, using `timeZone: 'UTC'` so the `YYYY-MM-DD` date string can't shift back a day for visitors in negative-offset timezones.

With the current dataset this renders **April 16, 2026**, and it will stay in sync with future dataset updates automatically.

## Verification

- `nuxt build` passes
- Formatter output checked: `2026-04-16` → "April 16, 2026"